### PR TITLE
Fix undefined DateFormat method

### DIFF
--- a/lib/features/home/views/widgets/attendance_status.dart
+++ b/lib/features/home/views/widgets/attendance_status.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hodorak/core/helper/spacing.dart';
+import 'package:intl/intl.dart';
 
 class AttendanceStatus extends StatelessWidget {
   const AttendanceStatus({super.key});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   font_awesome_flutter: ^10.10.0
   google_fonts: ^6.3.1
   http: ^1.5.0
+  intl: ^0.19.0
   odoo_rpc: ^0.7.1
   page_transition: ^2.2.1
   path_provider: ^2.1.4


### PR DESCRIPTION
Add `intl` package dependency and import `DateFormat` to resolve the 'DateFormat' isn't defined error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2f316ff-d666-4764-b041-1d8592e3e892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2f316ff-d666-4764-b041-1d8592e3e892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

